### PR TITLE
fix: add missing graphql port

### DIFF
--- a/tce.yml
+++ b/tce.yml
@@ -21,6 +21,7 @@ services:
       - RUST_BACKTRACE=full
       - TCE_DB_PATH=/tmp/default-db
       - TCE_API_ADDR=0.0.0.0:1340
+      - TCE_GRAPHQL_API_ADDR=0.0.0.0:4000
       - TCE_LOCAL_KS=1 # 12D3KooWRhFCXBhmsMnur3up3vJsDoqWh4c39PKXgSWwzAzDHNLn
       - TOPOS_OTLP_SERVICE_NAME=local-tce-boot-node
       - TOPOS_OTLP_AGENT=https://grpc.otel-collector.telemetry.devnet-1.toposware.com
@@ -59,6 +60,7 @@ services:
       - RUST_LOG=info,topos=info
       - TCE_DB_PATH=/tmp/default-db
       - TCE_API_ADDR=0.0.0.0:1340
+      - TCE_GRAPHQL_API_ADDR=0.0.0.0:4000
       - TOPOS_OTLP_SERVICE_NAME=local-tce-peer-node
       - TOPOS_OTLP_AGENT=https://grpc.otel-collector.telemetry.devnet-1.toposware.com
       - TCE_ECHO_SAMPLE_SIZE=4


### PR DESCRIPTION
# Description

This PR adds the missing `TCE_GRAPHQL_API_ADDR` env var for TCE nodes.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
