### PR TITLE
fix: use topos core proxy address for executor service

### DIFF
--- a/executor-service.yml
+++ b/executor-service.yml
@@ -21,6 +21,7 @@ services:
       - contracts:/contracts
     command: bash -c "
       source /contracts/.env &&
+      export TOPOS_CORE_CONTRACT_ADDRESS=$(printenv TOPOS_CORE_PROXY_CONTRACT_ADDRESS) &&
       npm run start:prod"
     environment:
       - PRIVATE_KEY=${PRIVATE_KEY}


### PR DESCRIPTION
# Description

This PR manually replaces the value of `TOPOS_CORE_CONTRACT_ADDRESS` used by the Executor Service with the address of the proxy. Until this fix, the non-proxy address had been used since the introduction of contract address abstraction.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
