### PR TITLE
feat: open graphql port on TCE boot node

### DIFF
--- a/tce.yml
+++ b/tce.yml
@@ -15,6 +15,7 @@ services:
     ports:
       - "9090"
       - "1340:1340"
+      - "4000:4000"
     environment:
       - RUST_LOG=info,topos=info
       - TOOLCHAIN_VERSION=stable


### PR DESCRIPTION
# Description

This PR opens the graphql `4000` port on the TCE bootnode.

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
